### PR TITLE
Fix for jdbc, which indexes the collumns from [1,size]

### DIFF
--- a/AndroidSQLiteBrowser/src/com/questoid/sqlitebrowser/view/SqliteBrowserView.java
+++ b/AndroidSQLiteBrowser/src/com/questoid/sqlitebrowser/view/SqliteBrowserView.java
@@ -224,7 +224,7 @@ public class SqliteBrowserView extends ViewPart {
 			while (rs.next()) {
 				final Object[] row = new Object[rsMeta.getColumnCount()];
 				for (int i = 0; i < rsMeta.getColumnCount(); i++) {
-					row[i] = rs.getString(i);
+					row[i] = rs.getString(i+1);
 				}
 				data.add(new DataRow(row, rowId));
 				rowId++;


### PR DESCRIPTION
Just a minor fix, in order to browse the data inside the sqlite database. Tested with Monitor bundled with Android Studio 1.3 in a 5.1.1 SQLite database file.
